### PR TITLE
fix: grep warning

### DIFF
--- a/INSTALL/tool/VentoyWorker.sh
+++ b/INSTALL/tool/VentoyWorker.sh
@@ -143,7 +143,7 @@ if grep "$DISK" /proc/mounts; then
 fi
 
 #check swap partition
-if swapon --help 2>&1 | grep -q '^ \-s,'; then
+if swapon --help 2>&1 | grep -q '^ -s,'; then
     if swapon -s | grep -q "^${DISK}[0-9]"; then
         vterr "$DISK is used as swap, please swapoff it first!"
         exit 1


### PR DESCRIPTION
With grep version 3.10, we get this warning when invoking `Ventoy2Disk.sh`:

```
grep: warning: stray \ before -
```

This is caused by an extra `\` right before a `-`. In a range, such as `[A-Z\-]`, this is necessary. However, outside of a range, this is superfluous. This one-line patch fixes the warning.

Older grep versions do not warn about this issue, which is likely why this warning is only seen recently.